### PR TITLE
Added get_first_paragraph function. 

### DIFF
--- a/leaders_scraper.py
+++ b/leaders_scraper.py
@@ -1,4 +1,6 @@
 import requests
+from bs4 import BeautifulSoup
+import string
 
 def get_leaders():
 
@@ -34,3 +36,38 @@ def get_leaders():
             print(req_leaders.status_code, f"Failed to retrieve leaders from: {country_code}")
 
     return leaders_per_country
+
+leaders_per_country = get_leaders()
+# print(leaders_per_country)
+
+def get_first_paragraph(wikipedia_url):
+    leader_first_name = None
+
+    for country_code, leaders in leaders_per_country.items():
+        for leader in leaders:
+            if leader['wikipedia_url'] == wikipedia_url:
+                leader_first_name = leader['first_name']
+                break
+        if leader_first_name:
+                break
+        
+    if not leader_first_name:
+         print("Leader not found for this URL.")
+         return None
+
+    print(wikipedia_url)
+
+    req_leader_wiki_url = requests.get(wikipedia_url)
+    soup = BeautifulSoup(req_leader_wiki_url.content, 'html.parser')
+
+    paragraphs = [p.text for p in soup.find_all("p")]
+
+    for first_paragraph in paragraphs:
+        if first_paragraph.strip():
+            first_word = first_paragraph.lstrip().split()[0].strip(string.punctuation).lower()
+            if first_word == leader_first_name.lower():
+                return first_paragraph
+            
+    return None
+
+# print(get_first_paragraph('https://fr.wikipedia.org/wiki/Emmanuel_Macron'))

--- a/wikipedia_scraper.ipynb
+++ b/wikipedia_scraper.ipynb
@@ -63,7 +63,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 84,
+   "execution_count": 7,
    "metadata": {
     "id": "9baoMWgIcK3E"
    },
@@ -107,7 +107,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 85,
+   "execution_count": 8,
    "metadata": {
     "id": "Y0DLiYCWcg5W"
    },
@@ -147,7 +147,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 86,
+   "execution_count": 9,
    "metadata": {
     "id": "dTDwpN9Q3nk_"
    },
@@ -180,11 +180,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "metadata": {
     "id": "9Y63sTXY7ppT"
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'message': 'The cookie is missing'}\n"
+     ]
+    }
+   ],
    "source": [
     "# query the /countries endpoint, assign the output to the countries variable (1 line)\n",
     "req = requests.get(f\"{root_url}/{countries_url}\")\n",
@@ -214,7 +222,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 87,
+   "execution_count": 11,
    "metadata": {
     "id": "ZwLFqcBA8PaD"
    },
@@ -249,7 +257,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 95,
+   "execution_count": 12,
    "metadata": {
     "id": "gIEFBhBeAkzf"
    },
@@ -267,7 +275,7 @@
        "{'message': 'The cookie is missing'}"
       ]
      },
-     "execution_count": 95,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -308,11 +316,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
    "metadata": {
     "id": "H8EdK2S9rvPJ"
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "403 Failed to retrieve leaders from: message\n",
+      "{}\n"
+     ]
+    }
+   ],
    "source": [
     "# 4 lines\n",
     "leaders_per_country = {}\n",
@@ -333,7 +350,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -356,7 +373,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 96,
+   "execution_count": 15,
    "metadata": {
     "id": "p6C7BgWQMxV2"
    },
@@ -408,7 +425,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 97,
+   "execution_count": 16,
    "metadata": {
     "id": "eXwd8o7Gu8yG"
    },
@@ -417,7 +434,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "200 <RequestsCookieJar[<Cookie user_cookie=6bc45b77-2071-4c36-9872-19ad4070b1cd for country-leaders.onrender.com/>]>\n",
+      "200 <RequestsCookieJar[<Cookie user_cookie=a0db62f6-a5a1-442e-b2fc-cd6e51ddccb5 for country-leaders.onrender.com/>]>\n",
       "200 ['us', 'be', 'ma', 'ru', 'fr']\n",
       "{'us': [{'id': 'Q23', 'first_name': 'George', 'last_name': 'Washington', 'birth_date': '1732-02-22', 'death_date': '1799-12-14', 'place_of_birth': 'Westmoreland County', 'wikipedia_url': 'https://en.wikipedia.org/wiki/George_Washington', 'start_mandate': '1789-04-30', 'end_mandate': '1797-03-04'}, {'id': 'Q76', 'first_name': 'Barack', 'last_name': 'Obama', 'birth_date': '1961-08-04', 'death_date': None, 'place_of_birth': 'Kapiolani Medical Center for Women and Children', 'wikipedia_url': 'https://en.wikipedia.org/wiki/Barack_Obama', 'start_mandate': '2009-01-20', 'end_mandate': '2017-01-20'}, {'id': 'Q91', 'first_name': 'Abraham', 'last_name': 'Lincoln', 'birth_date': '1809-02-12', 'death_date': '1865-04-15', 'place_of_birth': 'Sinking Spring Farm', 'wikipedia_url': 'https://en.wikipedia.org/wiki/Abraham_Lincoln', 'start_mandate': '1861-03-04', 'end_mandate': '1865-04-15'}, {'id': 'Q207', 'first_name': 'George', 'last_name': 'Bush', 'birth_date': '1946-07-06', 'death_date': None, 'place_of_birth': 'New Haven', 'wikipedia_url': 'https://en.wikipedia.org/wiki/George_W._Bush', 'start_mandate': '2001-01-20', 'end_mandate': '2009-01-20'}, {'id': 'Q1124', 'first_name': 'Bill', 'last_name': 'Clinton', 'birth_date': '1946-08-19', 'death_date': None, 'place_of_birth': 'Hope', 'wikipedia_url': 'https://en.wikipedia.org/wiki/Bill_Clinton', 'start_mandate': '1993-01-20', 'end_mandate': '2001-01-20'}, {'id': 'Q6279', 'first_name': 'Joe', 'last_name': 'Biden', 'birth_date': '1942-11-20', 'death_date': None, 'place_of_birth': \"St. Mary's Hospital\", 'wikipedia_url': 'https://en.wikipedia.org/wiki/Joe_Biden', 'start_mandate': '2021-01-20', 'end_mandate': None}, {'id': 'Q8007', 'first_name': 'Franklin', 'last_name': 'Roosevelt', 'birth_date': '1882-01-30', 'death_date': '1945-04-12', 'place_of_birth': 'Hyde Park', 'wikipedia_url': 'https://en.wikipedia.org/wiki/Franklin_D._Roosevelt', 'start_mandate': '1933-03-04', 'end_mandate': '1945-04-12'}, {'id': 'Q8612', 'first_name': 'Andrew', 'last_name': 'Johnson', 'birth_date': '1808-12-29', 'death_date': '1875-07-31', 'place_of_birth': 'Raleigh', 'wikipedia_url': 'https://en.wikipedia.org/wiki/Andrew_Johnson', 'start_mandate': '1865-04-15', 'end_mandate': '1869-03-04'}, {'id': 'Q9582', 'first_name': 'Gerald', 'last_name': 'Ford', 'birth_date': '1913-07-14', 'death_date': '2006-12-26', 'place_of_birth': 'Omaha', 'wikipedia_url': 'https://en.wikipedia.org/wiki/Gerald_Ford', 'start_mandate': '1974-08-09', 'end_mandate': '1977-01-20'}, {'id': 'Q9588', 'first_name': 'Richard', 'last_name': 'Nixon', 'birth_date': '1913-01-09', 'death_date': '1994-04-22', 'place_of_birth': 'Yorba Linda', 'wikipedia_url': 'https://en.wikipedia.org/wiki/Richard_Nixon', 'start_mandate': '1969-01-20', 'end_mandate': '1974-08-09'}, {'id': 'Q9640', 'first_name': 'Lyndon', 'last_name': 'Johnson', 'birth_date': '1908-08-27', 'death_date': '1973-01-22', 'place_of_birth': 'Stonewall', 'wikipedia_url': 'https://en.wikipedia.org/wiki/Lyndon_B._Johnson', 'start_mandate': '1963-11-22', 'end_mandate': '1969-01-20'}, {'id': 'Q9696', 'first_name': 'John', 'last_name': 'Kennedy', 'birth_date': '1917-05-29', 'death_date': '1963-11-22', 'place_of_birth': 'Brookline', 'wikipedia_url': 'https://en.wikipedia.org/wiki/John_F._Kennedy', 'start_mandate': '1961-01-20', 'end_mandate': '1963-11-22'}, {'id': 'Q9916', 'first_name': 'Dwight', 'last_name': 'Eisenhower', 'birth_date': '1890-10-14', 'death_date': '1969-03-28', 'place_of_birth': 'Denison', 'wikipedia_url': 'https://en.wikipedia.org/wiki/Dwight_D._Eisenhower', 'start_mandate': '1953-01-20', 'end_mandate': '1961-01-20'}, {'id': 'Q9960', 'first_name': 'Ronald', 'last_name': 'Reagan', 'birth_date': '1911-02-06', 'death_date': '2004-06-05', 'place_of_birth': 'Tampico', 'wikipedia_url': 'https://en.wikipedia.org/wiki/Ronald_Reagan', 'start_mandate': '1981-01-20', 'end_mandate': '1989-01-20'}, {'id': 'Q11613', 'first_name': 'Harry', 'last_name': 'Truman', 'birth_date': '1884-05-08', 'death_date': '1972-12-26', 'place_of_birth': 'Lamar', 'wikipedia_url': 'https://en.wikipedia.org/wiki/Harry_S._Truman', 'start_mandate': '1945-04-12', 'end_mandate': '1953-01-20'}, {'id': 'Q11806', 'first_name': 'John', 'last_name': 'Adams', 'birth_date': None, 'death_date': '1826-07-04', 'place_of_birth': 'Braintree', 'wikipedia_url': 'https://en.wikipedia.org/wiki/John_Adams', 'start_mandate': '1797-03-04', 'end_mandate': '1801-03-04'}, {'id': 'Q11812', 'first_name': 'Thomas', 'last_name': 'Jefferson', 'birth_date': None, 'death_date': '1826-07-04', 'place_of_birth': 'Shadwell', 'wikipedia_url': 'https://en.wikipedia.org/wiki/Thomas_Jefferson', 'start_mandate': '1801-03-04', 'end_mandate': '1809-03-04'}, {'id': 'Q11813', 'first_name': 'James', 'last_name': 'Madison', 'birth_date': '1751-03-16', 'death_date': '1836-06-28', 'place_of_birth': 'Port Conway', 'wikipedia_url': 'https://en.wikipedia.org/wiki/James_Madison', 'start_mandate': '1809-03-04', 'end_mandate': '1817-03-04'}, {'id': 'Q11815', 'first_name': 'James', 'last_name': 'Monroe', 'birth_date': '1758-04-28', 'death_date': '1831-07-04', 'place_of_birth': 'Monroe Hall', 'wikipedia_url': 'https://en.wikipedia.org/wiki/James_Monroe', 'start_mandate': '1817-03-04', 'end_mandate': '1825-03-04'}, {'id': 'Q11816', 'first_name': 'John', 'last_name': 'Adams', 'birth_date': '1767-07-11', 'death_date': '1848-02-23', 'place_of_birth': 'Braintree', 'wikipedia_url': 'https://en.wikipedia.org/wiki/John_Quincy_Adams', 'start_mandate': '1825-03-04', 'end_mandate': '1829-03-04'}, {'id': 'Q11817', 'first_name': 'Andrew', 'last_name': 'Jackson', 'birth_date': '1767-03-15', 'death_date': '1845-06-08', 'place_of_birth': 'Waxhaws', 'wikipedia_url': 'https://en.wikipedia.org/wiki/Andrew_Jackson', 'start_mandate': '1829-03-04', 'end_mandate': '1837-03-04'}, {'id': 'Q11820', 'first_name': 'Martin', 'last_name': 'Van Buren', 'birth_date': '1782-12-05', 'death_date': '1862-07-24', 'place_of_birth': 'Kinderhook', 'wikipedia_url': 'https://en.wikipedia.org/wiki/Martin_Van_Buren', 'start_mandate': '1837-03-04', 'end_mandate': '1841-03-04'}, {'id': 'Q11869', 'first_name': 'William', 'last_name': 'Harrison', 'birth_date': '1773-02-09', 'death_date': '1841-04-04', 'place_of_birth': 'Charles City County', 'wikipedia_url': 'https://en.wikipedia.org/wiki/William_Henry_Harrison', 'start_mandate': '1841-03-04', 'end_mandate': '1841-04-04'}, {'id': 'Q11881', 'first_name': 'John', 'last_name': 'Tyler', 'birth_date': '1790-03-29', 'death_date': '1862-01-18', 'place_of_birth': 'Charles City County', 'wikipedia_url': 'https://en.wikipedia.org/wiki/John_Tyler', 'start_mandate': '1841-04-04', 'end_mandate': '1845-03-04'}, {'id': 'Q11891', 'first_name': 'James', 'last_name': 'Polk', 'birth_date': '1795-11-02', 'death_date': '1849-06-15', 'place_of_birth': 'Pineville', 'wikipedia_url': 'https://en.wikipedia.org/wiki/James_K._Polk', 'start_mandate': '1845-03-04', 'end_mandate': '1849-03-04'}, {'id': 'Q11896', 'first_name': 'Zachary', 'last_name': 'Taylor', 'birth_date': '1784-11-24', 'death_date': '1850-07-09', 'place_of_birth': 'Barboursville', 'wikipedia_url': 'https://en.wikipedia.org/wiki/Zachary_Taylor', 'start_mandate': '1849-03-04', 'end_mandate': '1850-07-09'}, {'id': 'Q12306', 'first_name': 'Millard', 'last_name': 'Fillmore', 'birth_date': '1800-01-07', 'death_date': '1874-03-08', 'place_of_birth': 'Summerhill', 'wikipedia_url': 'https://en.wikipedia.org/wiki/Millard_Fillmore', 'start_mandate': '1850-07-09', 'end_mandate': '1853-03-04'}, {'id': 'Q12312', 'first_name': 'Franklin', 'last_name': 'Pierce', 'birth_date': '1804-11-23', 'death_date': '1869-10-08', 'place_of_birth': 'Hillsborough', 'wikipedia_url': 'https://en.wikipedia.org/wiki/Franklin_Pierce', 'start_mandate': '1853-03-04', 'end_mandate': '1857-03-04'}, {'id': 'Q12325', 'first_name': 'James', 'last_name': 'Buchanan', 'birth_date': '1791-04-23', 'death_date': '1868-06-01', 'place_of_birth': 'Stony Batter', 'wikipedia_url': 'https://en.wikipedia.org/wiki/James_Buchanan', 'start_mandate': '1857-03-04', 'end_mandate': '1861-03-04'}, {'id': 'Q22686', 'first_name': 'Donald', 'last_name': 'Trump', 'birth_date': '1946-06-14', 'death_date': None, 'place_of_birth': 'Jamaica Hospital Medical Center', 'wikipedia_url': 'https://en.wikipedia.org/wiki/Donald_Trump', 'start_mandate': '2017-01-20', 'end_mandate': '2021-01-20'}, {'id': 'Q23505', 'first_name': 'George', 'last_name': 'Bush', 'birth_date': '1924-06-12', 'death_date': '2018-11-30', 'place_of_birth': 'Milton', 'wikipedia_url': 'https://en.wikipedia.org/wiki/George_H._W._Bush', 'start_mandate': '1989-01-20', 'end_mandate': '1993-01-20'}, {'id': 'Q23685', 'first_name': 'Jimmy', 'last_name': 'Carter', 'birth_date': '1924-10-01', 'death_date': None, 'place_of_birth': 'Lillian G. Carter Nursing Center', 'wikipedia_url': 'https://en.wikipedia.org/wiki/Jimmy_Carter', 'start_mandate': '1977-01-20', 'end_mandate': '1981-01-20'}, {'id': 'Q33866', 'first_name': 'Theodore', 'last_name': 'Roosevelt', 'birth_date': '1858-10-27', 'death_date': '1919-01-06', 'place_of_birth': 'Manhattan', 'wikipedia_url': 'https://en.wikipedia.org/wiki/Theodore_Roosevelt', 'start_mandate': '1901-09-14', 'end_mandate': '1909-03-04'}, {'id': 'Q34296', 'first_name': 'Woodrow', 'last_name': 'Wilson', 'birth_date': '1856-12-28', 'death_date': '1924-02-03', 'place_of_birth': 'Staunton', 'wikipedia_url': 'https://en.wikipedia.org/wiki/Woodrow_Wilson', 'start_mandate': '1913-03-04', 'end_mandate': '1921-03-04'}, {'id': 'Q34597', 'first_name': 'James', 'last_name': 'Garfield', 'birth_date': '1831-11-19', 'death_date': '1881-09-19', 'place_of_birth': 'Moreland Hills', 'wikipedia_url': 'https://en.wikipedia.org/wiki/James_A._Garfield', 'start_mandate': '1881-03-04', 'end_mandate': '1881-09-19'}, {'id': 'Q34836', 'first_name': 'Ulysses', 'last_name': 'Grant', 'birth_date': '1822-04-27', 'death_date': '1885-07-23', 'place_of_birth': 'Point Pleasant', 'wikipedia_url': 'https://en.wikipedia.org/wiki/Ulysses_S._Grant', 'start_mandate': '1869-03-04', 'end_mandate': '1877-03-04'}, {'id': 'Q35041', 'first_name': 'William', 'last_name': 'McKinley', 'birth_date': '1843-01-29', 'death_date': '1901-09-14', 'place_of_birth': 'Niles', 'wikipedia_url': 'https://en.wikipedia.org/wiki/William_McKinley', 'start_mandate': '1897-03-04', 'end_mandate': '1901-09-14'}, {'id': 'Q35171', 'first_name': 'Stephen', 'last_name': 'Cleveland', 'birth_date': '1837-03-18', 'death_date': '1908-06-24', 'place_of_birth': 'Caldwell', 'wikipedia_url': 'https://en.wikipedia.org/wiki/Grover_Cleveland', 'start_mandate': '1893-03-04', 'end_mandate': '1897-03-04'}, {'id': 'Q35236', 'first_name': 'Herbert', 'last_name': 'Hoover', 'birth_date': '1874-08-10', 'death_date': '1964-10-20', 'place_of_birth': 'West Branch', 'wikipedia_url': 'https://en.wikipedia.org/wiki/Herbert_Hoover', 'start_mandate': '1929-03-04', 'end_mandate': '1933-03-04'}, {'id': 'Q35286', 'first_name': 'Warren', 'last_name': 'Harding', 'birth_date': '1865-11-02', 'death_date': '1923-08-02', 'place_of_birth': 'Blooming Grove', 'wikipedia_url': 'https://en.wikipedia.org/wiki/Warren_G._Harding', 'start_mandate': '1921-03-04', 'end_mandate': '1923-08-02'}, {'id': 'Q35498', 'first_name': 'Chester', 'last_name': 'Arthur', 'birth_date': '1829-10-05', 'death_date': '1886-11-18', 'place_of_birth': 'Fairfield', 'wikipedia_url': 'https://en.wikipedia.org/wiki/Chester_A._Arthur', 'start_mandate': '1881-09-19', 'end_mandate': '1885-03-04'}, {'id': 'Q35648', 'first_name': 'William', 'last_name': 'Taft', 'birth_date': '1857-09-15', 'death_date': '1930-03-08', 'place_of_birth': 'Cincinnati', 'wikipedia_url': 'https://en.wikipedia.org/wiki/William_Howard_Taft', 'start_mandate': '1909-03-04', 'end_mandate': '1913-03-04'}, {'id': 'Q35678', 'first_name': 'Benjamin', 'last_name': 'Harrison', 'birth_date': '1833-08-20', 'death_date': '1901-03-13', 'place_of_birth': 'North Bend', 'wikipedia_url': 'https://en.wikipedia.org/wiki/Benjamin_Harrison', 'start_mandate': '1889-03-04', 'end_mandate': '1893-03-04'}, {'id': 'Q35686', 'first_name': 'Rutherford', 'last_name': 'Hayes', 'birth_date': '1822-10-04', 'death_date': '1893-01-17', 'place_of_birth': 'Delaware', 'wikipedia_url': 'https://en.wikipedia.org/wiki/Rutherford_B._Hayes', 'start_mandate': '1877-03-04', 'end_mandate': '1881-03-04'}, {'id': 'Q36023', 'first_name': 'John', 'last_name': 'Coolidge', 'birth_date': '1872-07-04', 'death_date': '1933-01-05', 'place_of_birth': 'Plymouth Notch', 'wikipedia_url': 'https://en.wikipedia.org/wiki/Calvin_Coolidge', 'start_mandate': '1923-08-02', 'end_mandate': '1929-03-04'}], 'be': [{'id': 'Q12978', 'first_name': 'Guy', 'last_name': 'Verhofstadt', 'birth_date': '1953-04-11', 'death_date': None, 'place_of_birth': 'Dendermonde', 'wikipedia_url': 'https://nl.wikipedia.org/wiki/Guy_Verhofstadt', 'start_mandate': '1999-07-12', 'end_mandate': '2008-03-20'}, {'id': 'Q12981', 'first_name': 'Yves', 'last_name': 'Leterme', 'birth_date': '1960-10-06', 'death_date': None, 'place_of_birth': 'Wervik', 'wikipedia_url': 'https://nl.wikipedia.org/wiki/Yves_Leterme', 'start_mandate': '2009-11-25', 'end_mandate': '2011-12-06'}, {'id': 'Q12983', 'first_name': 'Herman', 'last_name': 'None', 'birth_date': '1947-10-31', 'death_date': None, 'place_of_birth': 'Etterbeek', 'wikipedia_url': 'https://nl.wikipedia.org/wiki/Herman_Van_Rompuy', 'start_mandate': '2008-12-30', 'end_mandate': '2009-11-25'}, {'id': 'Q14989', 'first_name': 'Léon', 'last_name': 'Delacroix', 'birth_date': '1867-12-27', 'death_date': '1929-10-15', 'place_of_birth': 'Saint-Josse-ten-Noode', 'wikipedia_url': 'https://nl.wikipedia.org/wiki/L%C3%A9on_Delacroix', 'start_mandate': '1918-11-21', 'end_mandate': '1920-11-20'}, {'id': 'Q14990', 'first_name': 'Henry', 'last_name': 'Carton', 'birth_date': '1869-01-31', 'death_date': '1951-05-06', 'place_of_birth': 'Brussels', 'wikipedia_url': 'https://nl.wikipedia.org/wiki/Henri_Carton_de_Wiart', 'start_mandate': '1920-11-20', 'end_mandate': '1921-12-16'}, {'id': 'Q14991', 'first_name': 'Georges', 'last_name': 'Theunis', 'birth_date': '1873-02-28', 'death_date': '1966-01-04', 'place_of_birth': 'Montegnée', 'wikipedia_url': 'https://nl.wikipedia.org/wiki/Georges_Theunis', 'start_mandate': '1934-11-20', 'end_mandate': '1935-03-25'}, {'id': 'Q14992', 'first_name': 'Aloïs', 'last_name': 'Van de Vyvere', 'birth_date': '1871-06-08', 'death_date': '1961-10-22', 'place_of_birth': 'Tielt', 'wikipedia_url': 'https://nl.wikipedia.org/wiki/Aloys_Van_de_Vyvere', 'start_mandate': '1925-05-13', 'end_mandate': '1925-06-17'}, {'id': 'Q14993', 'first_name': 'Prosper', 'last_name': 'Poullet', 'birth_date': '1868-03-05', 'death_date': '1937-12-03', 'place_of_birth': 'Leuven', 'wikipedia_url': 'https://nl.wikipedia.org/wiki/Prosper_Poullet', 'start_mandate': '1925-06-17', 'end_mandate': '1926-05-20'}, {'id': 'Q14994', 'first_name': 'Henri', 'last_name': 'Jaspar', 'birth_date': '1870-07-28', 'death_date': '1939-02-15', 'place_of_birth': 'Schaerbeek - Schaarbeek', 'wikipedia_url': 'https://nl.wikipedia.org/wiki/Henri_Jaspar', 'start_mandate': '1926-05-20', 'end_mandate': '1931-06-06'}, {'id': 'Q14995', 'first_name': 'Jules', 'last_name': 'None', 'birth_date': '1862-12-03', 'death_date': '1934-07-15', 'place_of_birth': 'Ixelles - Elsene', 'wikipedia_url': 'https://nl.wikipedia.org/wiki/Jules_Renkin', 'start_mandate': '1931-06-06', 'end_mandate': '1932-10-22'}, {'id': 'Q14996', 'first_name': 'Paul', 'last_name': 'Van Zeeland', 'birth_date': '1893-11-11', 'death_date': '1973-09-22', 'place_of_birth': 'Soignies', 'wikipedia_url': 'https://nl.wikipedia.org/wiki/Paul_van_Zeeland', 'start_mandate': '1935-03-25', 'end_mandate': '1937-11-24'}, {'id': 'Q14997', 'first_name': 'Achille', 'last_name': 'Van Acker', 'birth_date': '1898-04-08', 'death_date': '1975-07-10', 'place_of_birth': 'Bruges', 'wikipedia_url': 'https://nl.wikipedia.org/wiki/Achiel_Van_Acker', 'start_mandate': '1954-04-23', 'end_mandate': '1958-06-26'}, {'id': 'Q14998', 'first_name': 'Camille', 'last_name': 'Huysmans', 'birth_date': '1871-05-26', 'death_date': '1968-02-25', 'place_of_birth': 'Bilzen', 'wikipedia_url': 'https://nl.wikipedia.org/wiki/Camille_Huysmans', 'start_mandate': '1946-08-03', 'end_mandate': '1947-03-20'}, {'id': 'Q14999', 'first_name': 'Gaston', 'last_name': 'Eyskens', 'birth_date': '1905-04-01', 'death_date': '1988-01-03', 'place_of_birth': 'Lier', 'wikipedia_url': 'https://nl.wikipedia.org/wiki/Gaston_Eyskens', 'start_mandate': '1968-07-17', 'end_mandate': '1973-01-26'}, {'id': 'Q15002', 'first_name': 'Leo', 'last_name': 'Tindemans', 'birth_date': '1922-04-16', 'death_date': '2014-12-26', 'place_of_birth': 'Zwijndrecht', 'wikipedia_url': 'https://nl.wikipedia.org/wiki/Leo_Tindemans', 'start_mandate': '1974-04-25', 'end_mandate': '1978-10-20'}, {'id': 'Q15048', 'first_name': 'Elio', 'last_name': 'Di Rupo', 'birth_date': '1951-07-18', 'death_date': None, 'place_of_birth': 'Morlanwelz', 'wikipedia_url': 'https://nl.wikipedia.org/wiki/Elio_Di_Rupo', 'start_mandate': '2011-12-06', 'end_mandate': '2014-10-11'}, {'id': 'Q15056', 'first_name': 'Jean-Luc', 'last_name': 'Dehaene', 'birth_date': '1940-08-07', 'death_date': '2014-05-15', 'place_of_birth': 'Montpellier', 'wikipedia_url': 'https://nl.wikipedia.org/wiki/Jean-Luc_Dehaene', 'start_mandate': '1992-03-07', 'end_mandate': '1999-07-12'}, {'id': 'Q15956', 'first_name': 'Frans', 'last_name': 'Schollaert', 'birth_date': '1851-08-19', 'death_date': '1917-06-29', 'place_of_birth': 'Wilsele', 'wikipedia_url': 'https://nl.wikipedia.org/wiki/Frans_Schollaert', 'start_mandate': '1908-01-09', 'end_mandate': '1911-06-17'}, {'id': 'Q143202', 'first_name': 'Pieter', 'last_name': 'Decker', 'birth_date': '1812-01-25', 'death_date': '1891-01-04', 'place_of_birth': 'Zele', 'wikipedia_url': 'https://nl.wikipedia.org/wiki/Pieter_de_Decker', 'start_mandate': '1855-03-30', 'end_mandate': '1857-11-09'}, {'id': 'Q155691', 'first_name': 'Paul-Henri', 'last_name': 'Spaak', 'birth_date': '1899-01-25', 'death_date': '1972-07-31', 'place_of_birth': 'Schaerbeek - Schaarbeek', 'wikipedia_url': 'https://nl.wikipedia.org/wiki/Paul-Henri_Spaak', 'start_mandate': '1947-03-20', 'end_mandate': '1949-08-11'}, {'id': 'Q202049', 'first_name': 'Auguste', 'last_name': 'Beernaert', 'birth_date': '1829-07-26', 'death_date': '1912-10-06', 'place_of_birth': 'Ostend', 'wikipedia_url': 'https://nl.wikipedia.org/wiki/Auguste_Beernaert', 'start_mandate': '1884-10-26', 'end_mandate': '1894-03-26'}, {'id': 'Q221781', 'first_name': 'Théodore', 'last_name': 'Lefèvre', 'birth_date': '1914-01-17', 'death_date': '1973-09-18', 'place_of_birth': 'Ghent', 'wikipedia_url': 'https://nl.wikipedia.org/wiki/Th%C3%A9o_Lef%C3%A8vre', 'start_mandate': '1961-04-25', 'end_mandate': '1965-07-28'}, {'id': 'Q250021', 'first_name': 'Paul', 'last_name': 'None', 'birth_date': '1919-05-22', 'death_date': '2001-01-09', 'place_of_birth': 'Forest', 'wikipedia_url': 'https://nl.wikipedia.org/wiki/Paul_Vanden_Boeynants', 'start_mandate': '1978-10-20', 'end_mandate': '1979-04-03'}, {'id': 'Q289570', 'first_name': 'Étienne', 'last_name': 'Gerlache', 'birth_date': '1785-12-26', 'death_date': '1871-02-10', 'place_of_birth': 'Château of Biourge', 'wikipedia_url': 'https://nl.wikipedia.org/wiki/Etienne_de_Gerlache', 'start_mandate': '1831-02-27', 'end_mandate': '1831-03-10'}, {'id': 'Q313809', 'first_name': 'Wilfried', 'last_name': 'Martens', 'birth_date': '1936-04-19', 'death_date': '2013-10-09', 'place_of_birth': 'Sleidinge', 'wikipedia_url': 'https://nl.wikipedia.org/wiki/Wilfried_Martens', 'start_mandate': '1981-12-17', 'end_mandate': '1992-03-07'}, {'id': 'Q349477', 'first_name': 'Mark', 'last_name': 'Eyskens', 'birth_date': '1933-04-29', 'death_date': None, 'place_of_birth': 'Leuven', 'wikipedia_url': 'https://nl.wikipedia.org/wiki/Mark_Eyskens', 'start_mandate': '1981-04-06', 'end_mandate': '1981-12-17'}, {'id': 'Q363942', 'first_name': 'Pierre', 'last_name': 'Harmel', 'birth_date': '1911-03-16', 'death_date': '2009-11-15', 'place_of_birth': 'Uccle', 'wikipedia_url': 'https://nl.wikipedia.org/wiki/Pierre_Harmel', 'start_mandate': '1965-07-28', 'end_mandate': '1966-03-19'}, {'id': 'Q442578', 'first_name': 'Hubert', 'last_name': 'Pierlot', 'birth_date': '1883-12-23', 'death_date': '1963-12-13', 'place_of_birth': 'Bertrix', 'wikipedia_url': 'https://nl.wikipedia.org/wiki/Hubert_Pierlot', 'start_mandate': '1939-02-22', 'end_mandate': '1945-02-12'}, {'id': 'Q446472', 'first_name': 'Jean-Baptiste', 'last_name': 'Nothomb', 'birth_date': '1805-07-03', 'death_date': '1881-09-16', 'place_of_birth': 'Messancy', 'wikipedia_url': 'https://nl.wikipedia.org/wiki/Jean-Baptiste_Nothomb', 'start_mandate': '1841-04-13', 'end_mandate': '1845-07-30'}, {'id': 'Q461745', 'first_name': 'Edmond', 'last_name': 'None', 'birth_date': '1915-04-18', 'death_date': '1997-06-15', 'place_of_birth': 'Lantremange', 'wikipedia_url': 'https://nl.wikipedia.org/wiki/Edmond_Leburton', 'start_mandate': '1973-01-26', 'end_mandate': '1974-04-25'}, {'id': 'Q461753', 'first_name': 'Jean', 'last_name': 'None', 'birth_date': '1900-04-10', 'death_date': '1977-10-11', 'place_of_birth': 'Frasnes-lez-Gosselies', 'wikipedia_url': 'https://nl.wikipedia.org/wiki/Jean_Duvieusart', 'start_mandate': '1950-06-08', 'end_mandate': '1950-08-16'}, {'id': 'Q468104', 'first_name': 'Joseph', 'last_name': 'Lebeau', 'birth_date': '1794-01-03', 'death_date': '1865-03-19', 'place_of_birth': 'Huy', 'wikipedia_url': 'https://nl.wikipedia.org/wiki/Joseph_Lebeau', 'start_mandate': '1840-04-18', 'end_mandate': '1841-04-13'}, {'id': 'Q468109', 'first_name': 'Charles', 'last_name': 'Rogier', 'birth_date': '1800-08-17', 'death_date': '1885-05-27', 'place_of_birth': 'Saint-Quentin', 'wikipedia_url': 'https://nl.wikipedia.org/wiki/Charles_Rogier', 'start_mandate': '1857-11-09', 'end_mandate': '1868-01-03'}, {'id': 'Q472257', 'first_name': 'Barthélemy', 'last_name': 'None', 'birth_date': '1794-02-26', 'death_date': '1874-08-24', 'place_of_birth': 'Kasteel van Schabroek', 'wikipedia_url': 'https://nl.wikipedia.org/wiki/Barth%C3%A9lemy_de_Theux_de_Meylandt', 'start_mandate': '1871-12-07', 'end_mandate': '1874-08-21'}, {'id': 'Q472276', 'first_name': 'Felix', 'last_name': 'None', 'birth_date': '1793-04-05', 'death_date': '1862-08-05', 'place_of_birth': 'Pittem', 'wikipedia_url': 'https://nl.wikipedia.org/wiki/Felix_de_M%C3%BBelenaere', 'start_mandate': '1831-07-24', 'end_mandate': '1832-10-20'}, {'id': 'Q476596', 'first_name': 'Alexander', 'last_name': 'De Croo', 'birth_date': '1975-11-03', 'death_date': None, 'place_of_birth': 'Vilvoorde', 'wikipedia_url': 'https://nl.wikipedia.org/wiki/Alexander_De_Croo', 'start_mandate': '2020-10-01', 'end_mandate': None}, {'id': 'Q527479', 'first_name': 'Henri', 'last_name': 'de Brouckère', 'birth_date': '1801-01-25', 'death_date': '1891-01-25', 'place_of_birth': 'Bruges', 'wikipedia_url': 'https://nl.wikipedia.org/wiki/Henri_de_Brouck%C3%A8re', 'start_mandate': '1852-10-31', 'end_mandate': '1855-03-30'}, {'id': 'Q533339', 'first_name': 'Albert', 'last_name': 'None', 'birth_date': '1790-05-26', 'death_date': '1873-05-05', 'place_of_birth': 'Tournai', 'wikipedia_url': 'https://nl.wikipedia.org/wiki/Albert_Goblet_d%27Alviella', 'start_mandate': '1832-10-20', 'end_mandate': '1834-08-04'}, {'id': 'Q546727', 'first_name': 'Sylvain', 'last_name': 'Weyer', 'birth_date': '1802-01-19', 'death_date': '1874-05-23', 'place_of_birth': 'Leuven', 'wikipedia_url': 'https://nl.wikipedia.org/wiki/Sylvain_Van_de_Weyer', 'start_mandate': '1845-07-30', 'end_mandate': '1846-03-31'}, {'id': 'Q569138', 'first_name': 'Jules', 'last_name': 'Burlet', 'birth_date': '1844-04-10', 'death_date': '1897-03-01', 'place_of_birth': 'Ixelles - Elsene', 'wikipedia_url': 'https://nl.wikipedia.org/wiki/Jules_de_Burlet', 'start_mandate': '1894-03-26', 'end_mandate': '1896-02-25'}, {'id': 'Q665955', 'first_name': 'Paul-Émile', 'last_name': 'None', 'birth_date': '1872-05-30', 'death_date': '1944-03-03', 'place_of_birth': 'Brussels metropolitan area', 'wikipedia_url': 'https://nl.wikipedia.org/wiki/Paul-Emile_Janson', 'start_mandate': '1937-11-24', 'end_mandate': '1938-05-15'}, {'id': 'Q678535', 'first_name': 'Jules', 'last_name': 'Malou', 'birth_date': '1810-10-19', 'death_date': '1886-07-11', 'place_of_birth': 'Ypres', 'wikipedia_url': 'https://nl.wikipedia.org/wiki/Jules_Malou', 'start_mandate': '1884-06-16', 'end_mandate': '1884-10-26'}, {'id': 'Q705103', 'first_name': 'Charles', 'last_name': 'Broqueville', 'birth_date': '1860-12-04', 'death_date': '1940-09-05', 'place_of_birth': 'Postel', 'wikipedia_url': 'https://nl.wikipedia.org/wiki/Charles_de_Broqueville', 'start_mandate': '1932-10-22', 'end_mandate': '1934-11-20'}, {'id': 'Q705111', 'first_name': 'Joseph', 'last_name': 'Pholien', 'birth_date': '1884-12-28', 'death_date': '1968-01-04', 'place_of_birth': 'Liège', 'wikipedia_url': 'https://nl.wikipedia.org/wiki/Joseph_Pholien', 'start_mandate': '1950-08-16', 'end_mandate': '1952-01-15'}, {'id': 'Q705128', 'first_name': 'Jean', 'last_name': 'Van Houtte', 'birth_date': '1907-03-17', 'death_date': '1991-05-23', 'place_of_birth': 'Ghent', 'wikipedia_url': 'https://nl.wikipedia.org/wiki/Jean_Van_Houtte', 'start_mandate': '1952-01-15', 'end_mandate': '1954-04-23'}, {'id': 'Q705791', 'first_name': 'Walthère', 'last_name': 'Frère', 'birth_date': '1812-04-22', 'death_date': '1896-01-02', 'place_of_birth': 'Liège', 'wikipedia_url': 'https://nl.wikipedia.org/wiki/Walth%C3%A8re_Fr%C3%A8re-Orban', 'start_mandate': '1878-06-19', 'end_mandate': '1884-06-16'}, {'id': 'Q719483', 'first_name': 'Gérard', 'last_name': 'Cooreman', 'birth_date': '1852-03-25', 'death_date': '1926-12-02', 'place_of_birth': 'Ghent', 'wikipedia_url': 'https://nl.wikipedia.org/wiki/Gerard_Cooreman', 'start_mandate': '1918-06-01', 'end_mandate': '1918-11-21'}, {'id': 'Q721772', 'first_name': 'Jules', 'last_name': 'Vandenpeereboom', 'birth_date': '1843-03-18', 'death_date': '1917-03-06', 'place_of_birth': 'Kortrijk', 'wikipedia_url': 'https://nl.wikipedia.org/wiki/Jules_Vandenpeereboom', 'start_mandate': '1899-01-24', 'end_mandate': '1899-08-05'}, {'id': 'Q721781', 'first_name': 'Paul', 'last_name': 'None', 'birth_date': '1843-05-13', 'death_date': '1913-09-09', 'place_of_birth': 'Ghent', 'wikipedia_url': 'https://nl.wikipedia.org/wiki/Paul_de_Smet_de_Naeyer', 'start_mandate': '1899-08-05', 'end_mandate': '1907-05-02'}, {'id': 'Q721798', 'first_name': 'Jules', 'last_name': 'Trooz', 'birth_date': '1857-02-21', 'death_date': '1907-12-31', 'place_of_birth': 'Leuven', 'wikipedia_url': 'https://nl.wikipedia.org/wiki/Jules_de_Trooz', 'start_mandate': '1907-05-02', 'end_mandate': '1907-12-31'}, {'id': 'Q725589', 'first_name': 'Jules', 'last_name': \"d'Anethan\", 'birth_date': '1803-04-23', 'death_date': '1888-10-08', 'place_of_birth': 'Brussels metropolitan area', 'wikipedia_url': 'https://nl.wikipedia.org/wiki/Jules_Joseph_d%27Anethan', 'start_mandate': '1870-07-02', 'end_mandate': '1871-12-07'}, {'id': 'Q950958', 'first_name': 'Charles', 'last_name': 'Michel', 'birth_date': '1975-12-21', 'death_date': None, 'place_of_birth': 'Namur', 'wikipedia_url': 'https://nl.wikipedia.org/wiki/Charles_Michel', 'start_mandate': '2014-10-11', 'end_mandate': '2019-10-27'}, {'id': 'Q18434995', 'first_name': 'Sophie', 'last_name': 'Wilmès', 'birth_date': '1975-01-15', 'death_date': None, 'place_of_birth': 'Ixelles - Elsene', 'wikipedia_url': 'https://nl.wikipedia.org/wiki/Sophie_Wilm%C3%A8s', 'start_mandate': '2019-10-27', 'end_mandate': '2020-10-01'}], 'ma': [{'id': 'Q57553', 'first_name': 'Mohammed', 'last_name': 'None', 'birth_date': '1963-08-21', 'death_date': None, 'place_of_birth': 'Rabat', 'wikipedia_url': 'https://ar.wikipedia.org/wiki/%D9%85%D8%AD%D9%85%D8%AF_%D8%A7%D9%84%D8%B3%D8%A7%D8%AF%D8%B3_%D8%A8%D9%86_%D8%A7%D9%84%D8%AD%D8%B3%D9%86', 'start_mandate': '1999-07-23', 'end_mandate': None}, {'id': 'Q69103', 'first_name': 'Hassan', 'last_name': 'None', 'birth_date': '1929-07-09', 'death_date': '1999-07-20', 'place_of_birth': 'Rabat', 'wikipedia_url': 'https://ar.wikipedia.org/wiki/%D8%A7%D9%84%D8%AD%D8%B3%D9%86_%D8%A7%D9%84%D8%AB%D8%A7%D9%86%D9%8A_%D8%A8%D9%86_%D9%85%D8%AD%D9%85%D8%AF', 'start_mandate': '1961-02-26', 'end_mandate': '1999-07-23'}, {'id': 'Q193874', 'first_name': 'Mohammed', 'last_name': 'None', 'birth_date': '1909-08-10', 'death_date': '1961-02-26', 'place_of_birth': 'Fez', 'wikipedia_url': 'https://ar.wikipedia.org/wiki/%D9%85%D8%AD%D9%85%D8%AF_%D8%A7%D9%84%D8%AE%D8%A7%D9%85%D8%B3_%D8%A8%D9%86_%D9%8A%D9%88%D8%B3%D9%81', 'start_mandate': '1957-08-14', 'end_mandate': '1961-02-26'}, {'id': 'Q334782', 'first_name': 'Mohammed', 'last_name': 'None', 'birth_date': None, 'death_date': None, 'place_of_birth': 'None', 'wikipedia_url': 'https://ar.wikipedia.org/wiki/%D8%A7%D9%84%D9%82%D8%A7%D8%A6%D9%85_%D8%A8%D8%A3%D9%85%D8%B1_%D8%A7%D9%84%D9%84%D9%87_%D8%A7%D9%84%D8%B3%D8%B9%D8%AF%D9%8A', 'start_mandate': None, 'end_mandate': '1517-01-01'}], 'ru': [{'id': 'Q7747', 'first_name': 'Vladimir', 'last_name': 'Putin', 'birth_date': '1952-10-07', 'death_date': None, 'place_of_birth': 'Saint Petersburg', 'wikipedia_url': 'https://ru.wikipedia.org/wiki/%D0%9F%D1%83%D1%82%D0%B8%D0%BD,_%D0%92%D0%BB%D0%B0%D0%B4%D0%B8%D0%BC%D0%B8%D1%80_%D0%92%D0%BB%D0%B0%D0%B4%D0%B8%D0%BC%D0%B8%D1%80%D0%BE%D0%B2%D0%B8%D1%87', 'start_mandate': '2000-05-07', 'end_mandate': '2008-05-07'}, {'id': 'Q23530', 'first_name': 'Dmitry', 'last_name': 'Medvedev', 'birth_date': '1965-09-14', 'death_date': None, 'place_of_birth': 'Saint Petersburg', 'wikipedia_url': 'https://ru.wikipedia.org/wiki/%D0%9C%D0%B5%D0%B4%D0%B2%D0%B5%D0%B4%D0%B5%D0%B2,_%D0%94%D0%BC%D0%B8%D1%82%D1%80%D0%B8%D0%B9_%D0%90%D0%BD%D0%B0%D1%82%D0%BE%D0%BB%D1%8C%D0%B5%D0%B2%D0%B8%D1%87', 'start_mandate': '2008-05-07', 'end_mandate': '2012-05-07'}, {'id': 'Q34453', 'first_name': 'Boris', 'last_name': 'Yeltsin', 'birth_date': '1931-02-01', 'death_date': '2007-04-23', 'place_of_birth': 'Butka', 'wikipedia_url': 'https://ru.wikipedia.org/wiki/%D0%95%D0%BB%D1%8C%D1%86%D0%B8%D0%BD,_%D0%91%D0%BE%D1%80%D0%B8%D1%81_%D0%9D%D0%B8%D0%BA%D0%BE%D0%BB%D0%B0%D0%B5%D0%B2%D0%B8%D1%87', 'start_mandate': '1991-07-10', 'end_mandate': '1999-12-31'}], 'fr': [{'id': 'Q157', 'first_name': 'François', 'last_name': 'Hollande', 'birth_date': '1954-08-12', 'death_date': None, 'place_of_birth': 'Rouen', 'wikipedia_url': 'https://fr.wikipedia.org/wiki/Fran%C3%A7ois_Hollande', 'start_mandate': '2012-05-15', 'end_mandate': '2017-05-14'}, {'id': 'Q329', 'first_name': 'Nicolas', 'last_name': 'Sarkozy', 'birth_date': '1955-01-28', 'death_date': None, 'place_of_birth': 'Paris', 'wikipedia_url': 'https://fr.wikipedia.org/wiki/Nicolas_Sarkozy', 'start_mandate': '2007-05-16', 'end_mandate': '2012-05-15'}, {'id': 'Q2038', 'first_name': 'François', 'last_name': 'Mitterrand', 'birth_date': '1916-10-26', 'death_date': '1996-01-08', 'place_of_birth': 'Jarnac', 'wikipedia_url': 'https://fr.wikipedia.org/wiki/Fran%C3%A7ois_Mitterrand', 'start_mandate': '1981-05-21', 'end_mandate': '1995-05-17'}, {'id': 'Q2042', 'first_name': 'Charles', 'last_name': 'de Gaulle', 'birth_date': '1890-11-22', 'death_date': '1970-11-09', 'place_of_birth': 'Lille', 'wikipedia_url': 'https://fr.wikipedia.org/wiki/Charles_de_Gaulle', 'start_mandate': '1959-01-08', 'end_mandate': '1969-04-28'}, {'id': 'Q2105', 'first_name': 'Jacques', 'last_name': 'Chirac', 'birth_date': '1932-11-29', 'death_date': '2019-09-26', 'place_of_birth': '5th arrondissement of Paris', 'wikipedia_url': 'https://fr.wikipedia.org/wiki/Jacques_Chirac', 'start_mandate': '1995-05-17', 'end_mandate': '2007-05-16'}, {'id': 'Q2124', 'first_name': 'Valéry', 'last_name': \"Giscard d'Estaing\", 'birth_date': '1926-02-02', 'death_date': '2020-12-02', 'place_of_birth': 'Koblenz', 'wikipedia_url': 'https://fr.wikipedia.org/wiki/Val%C3%A9ry_Giscard_d%27Estaing', 'start_mandate': '1974-05-27', 'end_mandate': '1981-05-21'}, {'id': 'Q2185', 'first_name': 'Georges', 'last_name': 'Pompidou', 'birth_date': '1911-07-05', 'death_date': '1974-04-02', 'place_of_birth': 'Montboudif', 'wikipedia_url': 'https://fr.wikipedia.org/wiki/Georges_Pompidou', 'start_mandate': '1969-06-20', 'end_mandate': '1974-04-02'}, {'id': 'Q5738', 'first_name': 'Adolphe', 'last_name': 'Thiers', 'birth_date': '1797-04-15', 'death_date': '1877-09-03', 'place_of_birth': 'Marseille', 'wikipedia_url': 'https://fr.wikipedia.org/wiki/Adolphe_Thiers', 'start_mandate': '1871-08-31', 'end_mandate': '1873-05-24'}, {'id': 'Q7721', 'first_name': 'Napoléon', 'last_name': 'Bonaparte', 'birth_date': '1808-04-20', 'death_date': '1873-01-09', 'place_of_birth': 'Paris', 'wikipedia_url': 'https://fr.wikipedia.org/wiki/Napol%C3%A9on_III', 'start_mandate': '1848-12-20', 'end_mandate': '1852-12-02'}, {'id': 'Q12680', 'first_name': 'Paul', 'last_name': 'Doumer', 'birth_date': '1857-03-22', 'death_date': '1932-05-07', 'place_of_birth': 'Aurillac', 'wikipedia_url': 'https://fr.wikipedia.org/wiki/Paul_Doumer', 'start_mandate': '1931-06-13', 'end_mandate': '1932-05-07'}, {'id': 'Q12950', 'first_name': 'Alain', 'last_name': 'Poher', 'birth_date': '1909-04-17', 'death_date': '1996-12-09', 'place_of_birth': 'Ablon-sur-Seine', 'wikipedia_url': 'https://fr.wikipedia.org/wiki/Alain_Poher', 'start_mandate': '1969-04-28', 'end_mandate': '1969-06-20'}, {'id': 'Q158749', 'first_name': 'Albert', 'last_name': 'Lebrun', 'birth_date': '1871-08-29', 'death_date': '1950-03-06', 'place_of_birth': 'Mercy-le-Haut', 'wikipedia_url': 'https://fr.wikipedia.org/wiki/Albert_Lebrun', 'start_mandate': '1932-05-10', 'end_mandate': '1940-07-11'}, {'id': 'Q158768', 'first_name': 'René', 'last_name': 'Coty', 'birth_date': '1882-03-20', 'death_date': '1962-11-22', 'place_of_birth': 'Le Havre', 'wikipedia_url': 'https://fr.wikipedia.org/wiki/Ren%C3%A9_Coty', 'start_mandate': '1954-01-16', 'end_mandate': '1959-01-08'}, {'id': 'Q158772', 'first_name': 'Vincent', 'last_name': 'Auriol', 'birth_date': '1884-08-27', 'death_date': '1966-01-01', 'place_of_birth': 'Revel', 'wikipedia_url': 'https://fr.wikipedia.org/wiki/Vincent_Auriol', 'start_mandate': '1947-01-16', 'end_mandate': '1954-01-16'}, {'id': 'Q158838', 'first_name': 'Patrice', 'last_name': 'de Mac Mahon', 'birth_date': '1808-06-13', 'death_date': '1893-10-17', 'place_of_birth': 'Sully', 'wikipedia_url': 'https://fr.wikipedia.org/wiki/Patrice_de_Mac_Mahon', 'start_mandate': '1873-05-24', 'end_mandate': '1879-01-30'}, {'id': 'Q169502', 'first_name': 'Émile', 'last_name': 'Loubet', 'birth_date': '1838-12-31', 'death_date': '1929-12-20', 'place_of_birth': 'Marsanne', 'wikipedia_url': 'https://fr.wikipedia.org/wiki/%C3%89mile_Loubet', 'start_mandate': '1899-02-18', 'end_mandate': '1906-02-18'}, {'id': 'Q191974', 'first_name': 'Raymond', 'last_name': 'Poincaré', 'birth_date': '1860-08-20', 'death_date': '1934-10-15', 'place_of_birth': 'Bar-le-Duc', 'wikipedia_url': 'https://fr.wikipedia.org/wiki/Raymond_Poincar%C3%A9', 'start_mandate': '1913-02-18', 'end_mandate': '1920-02-18'}, {'id': 'Q215778', 'first_name': 'Marie', 'last_name': 'Carnot', 'birth_date': '1837-08-11', 'death_date': '1894-06-25', 'place_of_birth': 'Limoges', 'wikipedia_url': 'https://fr.wikipedia.org/wiki/Sadi_Carnot_(homme_d%27%C3%89tat)', 'start_mandate': '1887-12-03', 'end_mandate': '1894-06-25'}, {'id': 'Q274540', 'first_name': 'Alexandre', 'last_name': 'Millerand', 'birth_date': '1859-02-10', 'death_date': '1943-04-06', 'place_of_birth': 'Paris', 'wikipedia_url': 'https://fr.wikipedia.org/wiki/Alexandre_Millerand', 'start_mandate': '1920-09-23', 'end_mandate': '1924-06-11'}, {'id': 'Q296064', 'first_name': 'Gaston', 'last_name': 'Doumergue', 'birth_date': '1863-08-01', 'death_date': '1937-06-18', 'place_of_birth': 'Aigues-Vives', 'wikipedia_url': 'https://fr.wikipedia.org/wiki/Gaston_Doumergue', 'start_mandate': '1924-06-13', 'end_mandate': '1931-06-13'}, {'id': 'Q296076', 'first_name': 'Félix', 'last_name': 'Faure', 'birth_date': '1841-01-30', 'death_date': '1899-02-16', 'place_of_birth': 'Paris', 'wikipedia_url': 'https://fr.wikipedia.org/wiki/F%C3%A9lix_Faure', 'start_mandate': '1895-01-17', 'end_mandate': '1899-02-16'}, {'id': 'Q296083', 'first_name': 'Jules', 'last_name': 'Grévy', 'birth_date': '1807-08-15', 'death_date': '1891-09-09', 'place_of_birth': 'Mont-sous-Vaudrey', 'wikipedia_url': 'https://fr.wikipedia.org/wiki/Jules_Gr%C3%A9vy', 'start_mandate': '1879-01-30', 'end_mandate': '1887-12-02'}, {'id': 'Q296673', 'first_name': 'Clément', 'last_name': 'Fallières', 'birth_date': '1841-11-06', 'death_date': '1931-06-22', 'place_of_birth': 'Mézin', 'wikipedia_url': 'https://fr.wikipedia.org/wiki/Armand_Falli%C3%A8res', 'start_mandate': '1906-02-18', 'end_mandate': '1913-02-18'}, {'id': 'Q309995', 'first_name': 'Paul', 'last_name': 'Deschanel', 'birth_date': '1855-02-13', 'death_date': '1922-04-28', 'place_of_birth': 'Schaerbeek - Schaarbeek', 'wikipedia_url': 'https://fr.wikipedia.org/wiki/Paul_Deschanel', 'start_mandate': '1920-02-18', 'end_mandate': '1920-09-21'}, {'id': 'Q312026', 'first_name': 'Georges', 'last_name': 'Bidault', 'birth_date': '1899-10-05', 'death_date': '1983-01-27', 'place_of_birth': 'Moulins', 'wikipedia_url': 'https://fr.wikipedia.org/wiki/Georges_Bidault', 'start_mandate': '1946-06-24', 'end_mandate': '1946-10-14'}, {'id': 'Q315656', 'first_name': 'Jean', 'last_name': 'Casimir-Perier', 'birth_date': '1847-11-08', 'death_date': '1907-03-11', 'place_of_birth': 'Paris', 'wikipedia_url': 'https://fr.wikipedia.org/wiki/Jean_Casimir-Perier', 'start_mandate': '1894-06-27', 'end_mandate': '1895-01-16'}, {'id': 'Q356032', 'first_name': 'Charles', 'last_name': 'Dupuy', 'birth_date': '1851-11-05', 'death_date': '1923-07-23', 'place_of_birth': 'Le Puy-en-Velay', 'wikipedia_url': 'https://fr.wikipedia.org/wiki/Charles_Dupuy', 'start_mandate': '1894-06-25', 'end_mandate': '1894-06-27'}, {'id': 'Q379702', 'first_name': 'Louis', 'last_name': 'Cavaignac', 'birth_date': '1802-10-15', 'death_date': '1857-10-28', 'place_of_birth': 'Paris', 'wikipedia_url': 'https://fr.wikipedia.org/wiki/Eug%C3%A8ne_Cavaignac', 'start_mandate': '1848-06-28', 'end_mandate': '1848-12-20'}, {'id': 'Q441235', 'first_name': 'Louis', 'last_name': 'None', 'birth_date': '1815-03-12', 'death_date': '1896-10-07', 'place_of_birth': 'Le Palais', 'wikipedia_url': 'https://fr.wikipedia.org/wiki/Louis_Jules_Trochu', 'start_mandate': '1870-09-04', 'end_mandate': '1871-01-22'}, {'id': 'Q459212', 'first_name': 'Frédéric', 'last_name': 'None', 'birth_date': '1874-03-16', 'death_date': '1958-05-20', 'place_of_birth': 'Paris', 'wikipedia_url': 'https://fr.wikipedia.org/wiki/Fr%C3%A9d%C3%A9ric_Fran%C3%A7ois-Marsal', 'start_mandate': '1924-06-11', 'end_mandate': '1924-06-13'}, {'id': 'Q3052772', 'first_name': 'Emmanuel', 'last_name': 'Macron', 'birth_date': '1977-12-21', 'death_date': None, 'place_of_birth': 'Amiens', 'wikipedia_url': 'https://fr.wikipedia.org/wiki/Emmanuel_Macron', 'start_mandate': '2017-05-14', 'end_mandate': None}]}\n"
      ]
@@ -442,7 +459,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 127,
+   "execution_count": 17,
    "metadata": {
     "id": "cEKKqyTHr3fD"
    },
@@ -459,7 +476,7 @@
       "<meta charset=\"UTF-8\">\n",
       "<title>Émile Loubet — Wikipédia</title>\n",
       "<script>(function(){var className=\"client-js vector-feature-language-in-header-enabled vector-feature-language-in-main-page-header-disabled vector-feature-sticky-header-disabled vector-feature-page-tools-pinned-disabled vector-feature-toc-pinned-clientpref-1 vector-feature-main-menu-pinned-disabled vector-feature-limited-width-clientpref-1 vector-feature-limited-width-content-enabled vector-feature-custom-font-size-clientpref-1 vector-feature-appearance-pinned-clientpref-1 vector-feature-night-mode-enabled skin-theme-clientpref-day vector-toc-available\";var cookie=document.cookie.match(/(?:^|; )frwikimwclientpreferences=([^;]+)/);if(cookie){cookie[1].split('%2C').forEach(function(pref){className=className.replace(new RegExp('(^| )'+pref.replace(/-clientpref-\\w+$|[^\\w-]+/g,'')+'-clientpref-\\\\w+( |$)'),'$1'+pref+'$2');});}document.documentElement.className=className;}());RLCONF={\"wgBreakFrames\":false,\"wgSeparatorTransformTable\":[\",\\t.\",\" \\t,\"],\"wgDigitTransformTable\":[\"\",\"\"],\n",
-      "\"wgDefaultDateFormat\":\"dmy\",\"wgMonthNames\":[\"\",\"janvier\",\"février\",\"mars\",\"avril\",\"mai\",\"juin\",\"juillet\",\"août\",\"septembre\",\"octobre\",\"novembre\",\"décembre\"],\"wgRequestId\":\"1413c6ee-09fd-43cf-98b5-bb822a24195d\",\"wgCanonicalNamespace\":\"\",\"wgCanonicalSpecialPageName\":false,\"wgNamespaceNumber\":0,\"wgPageName\":\"Émile_Loubet\",\"wgTitle\":\"Émile Loubet\",\"wgCurRevisionId\":219996891,\"wgRevisionId\":219996891,\"wgArticleId\":53684,\"wgIsArticle\":true,\"wgIsRedirect\":false,\"wgAction\":\"view\",\"wgUserName\":null,\"wgUserGroups\":[\"*\"],\"wgCategories\":[\"Article utilisant une Infobox\",\"Article à référence nécessaire\",\"Catégorie Commons avec lien local identique sur Wikidata\",\"Page utilisant P11152\",\"Page utilisant P1808\",\"Page utilisant P1045\",\"Page pointant vers des bases externes\",\"Page pointant vers des bases relatives à la vie publique\",\"Page utilisant P1816\",\"Page pointant vers des bases relatives aux beaux-arts\",\"Page utilisant P1417\",\"Page utilisant P5019\",\"Page utilisant P8313\",\n",
+      "\"wgDefaultDateFormat\":\"dmy\",\"wgMonthNames\":[\"\",\"janvier\",\"février\",\"mars\",\"avril\",\"mai\",\"juin\",\"juillet\",\"août\",\"septembre\",\"octobre\",\"novembre\",\"décembre\"],\"wgRequestId\":\"e02916fc-bed3-47b0-b020-bc30eb87d255\",\"wgCanonicalNamespace\":\"\",\"wgCanonicalSpecialPageName\":false,\"wgNamespaceNumber\":0,\"wgPageName\":\"Émile_Loubet\",\"wgTitle\":\"Émile Loubet\",\"wgCurRevisionId\":219996891,\"wgRevisionId\":219996891,\"wgArticleId\":53684,\"wgIsArticle\":true,\"wgIsRedirect\":false,\"wgAction\":\"view\",\"wgUserName\":null,\"wgUserGroups\":[\"*\"],\"wgCategories\":[\"Article utilisant une Infobox\",\"Article à référence nécessaire\",\"Catégorie Commons avec lien local identique sur Wikidata\",\"Page utilisant P11152\",\"Page utilisant P1808\",\"Page utilisant P1045\",\"Page pointant vers des bases externes\",\"Page pointant vers des bases relatives à la vie publique\",\"Page utilisant P1816\",\"Page pointant vers des bases relatives aux beaux-arts\",\"Page utilisant P1417\",\"Page utilisant P5019\",\"Page utilisant P8313\",\n",
       "\"Page utilisant P7902\",\"Page utilisant P6404\",\"Page utilisant P6706\",\"Page utilisant P3222\",\"Page utilisant P4342\",\"Page utilisant P3365\",\"Page utilisant P3219\",\"Page utilisant P7666\",\"Page pointant vers des dictionnaires ou encyclopédies généralistes\",\"Article de Wikipédia avec notice d'autorité\",\"Portail:Politique française/Articles liés\",\"Portail:Politique/Articles liés\",\"Portail:France/Articles liés\",\"Portail:Europe/Articles liés\",\"Portail:Drôme/Articles liés\",\"Portail:Auvergne-Rhône-Alpes/Articles liés\",\"Wikipédia:Article biographique\",\"Portail:Biographie/Articles liés/Politique\",\"Portail:Biographie/Articles liés/Entreprises\",\"Émile Loubet\",\"Naissance en décembre 1838\",\"Naissance dans la Drôme provençale\",\"Étudiant de la faculté de droit de Paris\",\"Personnalité liée à la Drôme provençale\",\"Conseiller général de la Drôme\",\"Député de la Drôme (Troisième République)\",\"Député de la première législature de la Troisième République\",\n",
       "\"Député de la deuxième législature de la Troisième République\",\"Député de la troisième législature de la Troisième République\",\"Maire de Montélimar\",\"Sénateur de la Troisième République française\",\"Sénateur de la Drôme\",\"Ministre de la Troisième République\",\"Ministre français des Transports\",\"Président du Conseil de la Troisième République\",\"Président du Sénat (France)\",\"Président de la République française\",\"Personnalité de l'Alliance démocratique\",\"Dreyfusard\",\"Grand-croix de la Légion d'honneur\",\"Chevalier de l'ordre de Saint-André\",\"Chevalier de l'ordre espagnol de la Toison d'or (XXe siècle)\",\"Coprince d'Andorre du XIXe siècle\",\"Coprince d'Andorre du XXe siècle\",\"Décès en décembre 1929\",\"Décès à Montélimar\",\"Décès à 90 ans\",\"Personnalité inhumée dans la Drôme\"],\"wgPageViewLanguage\":\"fr\",\"wgPageContentLanguage\":\"fr\",\"wgPageContentModel\":\"wikitext\",\"wgRelevantPageName\":\"Émile_Loubet\",\"wgRelevantArticleId\":53684,\n",
       "\"wgIsProbablyEditable\":true,\"wgRelevantPageIsProbablyEditable\":true,\"wgRestrictionEdit\":[],\"wgRestrictionMove\":[],\"wgNoticeProject\":\"wikipedia\",\"wgCiteReferencePreviewsActive\":true,\"wgMediaViewerOnClick\":true,\"wgMediaViewerEnabledByDefault\":true,\"wgPopupsFlags\":0,\"wgVisualEditor\":{\"pageLanguageCode\":\"fr\",\"pageLanguageDir\":\"ltr\",\"pageVariantFallbacks\":\"fr\"},\"wgMFDisplayWikibaseDescriptions\":{\"search\":true,\"watchlist\":true,\"tagline\":true,\"nearby\":true},\"wgWMESchemaEditAttemptStepOversample\":false,\"wgWMEPageLength\":30000,\"wgRelatedArticlesCompat\":[],\"wgCentralAuthMobileDomain\":false,\"wgEditSubmitButtonLabelPublish\":true,\"wgULSPosition\":\"interlanguage\",\"wgULSisCompactLinksEnabled\":false,\"wgVector2022LanguageInHeader\":true,\"wgULSisLanguageSelectorEmpty\":false,\"wgWikibaseItemId\":\"Q169502\",\"wgCheckUserClientHintsHeadersJsApi\":[\"architecture\",\"bitness\",\"brands\",\"fullVersionList\",\"mobile\",\"model\",\"platform\",\"platformVersion\"],\"GEHomepageSuggestedEditsEnableTopics\":true,\n",
@@ -2974,7 +2991,7 @@
       "</div> \n",
       "<div class=\"vector-settings\" id=\"p-dock-bottom\">\n",
       "\t<ul></ul>\n",
-      "</div><script>(RLQ=window.RLQ||[]).push(function(){mw.config.set({\"wgHostname\":\"mw-web.eqiad.main-6b6c9bdc8b-88khx\",\"wgBackendResponseTime\":206,\"wgPageParseReport\":{\"limitreport\":{\"cputime\":\"1.303\",\"walltime\":\"1.653\",\"ppvisitednodes\":{\"value\":16389,\"limit\":1000000},\"postexpandincludesize\":{\"value\":403027,\"limit\":2097152},\"templateargumentsize\":{\"value\":116931,\"limit\":2097152},\"expansiondepth\":{\"value\":17,\"limit\":100},\"expensivefunctioncount\":{\"value\":7,\"limit\":500},\"unstrip-depth\":{\"value\":0,\"limit\":20},\"unstrip-size\":{\"value\":14014,\"limit\":5000000},\"entityaccesscount\":{\"value\":10,\"limit\":400},\"timingprofile\":[\"100.00% 1335.769      1 -total\",\" 37.52%  501.166      1 Modèle:Liens\",\" 22.57%  301.540      1 Modèle:Infobox_Personnalité_politique\",\" 11.97%  159.913     20 Modèle:Infobox_Personnalité_politique/Fonction\",\"  9.72%  129.795      1 Modèle:Palette\",\"  8.08%  107.961    585 Modèle:Infobox/Ligne_mixte_optionnelle\",\"  7.07%   94.378      2 Modèle:Références\",\"  6.19%   82.726      6 Modèle:Méta_palette_de_navigation\",\"  4.50%   60.160      1 Modèle:Portail\",\"  3.61%   48.171     32 Modèle:Infobox/Ligne_optionnelle\"]},\"scribunto\":{\"limitreport-timeusage\":{\"value\":\"0.581\",\"limit\":\"10.000\"},\"limitreport-memusage\":{\"value\":9671216,\"limit\":52428800}},\"cachereport\":{\"origin\":\"mw-web.eqiad.main-6b6c9bdc8b-kj2nb\",\"timestamp\":\"20241103192646\",\"ttl\":2592000,\"transientcontent\":false}}});});</script>\n",
+      "</div><script>(RLQ=window.RLQ||[]).push(function(){mw.config.set({\"wgHostname\":\"mw-web.eqiad.main-56895c6b89-qrttm\",\"wgBackendResponseTime\":179,\"wgPageParseReport\":{\"limitreport\":{\"cputime\":\"1.303\",\"walltime\":\"1.653\",\"ppvisitednodes\":{\"value\":16389,\"limit\":1000000},\"postexpandincludesize\":{\"value\":403027,\"limit\":2097152},\"templateargumentsize\":{\"value\":116931,\"limit\":2097152},\"expansiondepth\":{\"value\":17,\"limit\":100},\"expensivefunctioncount\":{\"value\":7,\"limit\":500},\"unstrip-depth\":{\"value\":0,\"limit\":20},\"unstrip-size\":{\"value\":14014,\"limit\":5000000},\"entityaccesscount\":{\"value\":10,\"limit\":400},\"timingprofile\":[\"100.00% 1335.769      1 -total\",\" 37.52%  501.166      1 Modèle:Liens\",\" 22.57%  301.540      1 Modèle:Infobox_Personnalité_politique\",\" 11.97%  159.913     20 Modèle:Infobox_Personnalité_politique/Fonction\",\"  9.72%  129.795      1 Modèle:Palette\",\"  8.08%  107.961    585 Modèle:Infobox/Ligne_mixte_optionnelle\",\"  7.07%   94.378      2 Modèle:Références\",\"  6.19%   82.726      6 Modèle:Méta_palette_de_navigation\",\"  4.50%   60.160      1 Modèle:Portail\",\"  3.61%   48.171     32 Modèle:Infobox/Ligne_optionnelle\"]},\"scribunto\":{\"limitreport-timeusage\":{\"value\":\"0.581\",\"limit\":\"10.000\"},\"limitreport-memusage\":{\"value\":9671216,\"limit\":52428800}},\"cachereport\":{\"origin\":\"mw-web.eqiad.main-6b6c9bdc8b-kj2nb\",\"timestamp\":\"20241103192646\",\"ttl\":2592000,\"transientcontent\":false}}});});</script>\n",
       "<script type=\"application/ld+json\">{\"@context\":\"https:\\/\\/schema.org\",\"@type\":\"Article\",\"name\":\"\\u00c9mile Loubet\",\"url\":\"https:\\/\\/fr.wikipedia.org\\/wiki\\/%C3%89mile_Loubet\",\"sameAs\":\"http:\\/\\/www.wikidata.org\\/entity\\/Q169502\",\"mainEntity\":\"http:\\/\\/www.wikidata.org\\/entity\\/Q169502\",\"author\":{\"@type\":\"Organization\",\"name\":\"Contributeurs aux projets Wikimedia\"},\"publisher\":{\"@type\":\"Organization\",\"name\":\"Fondation Wikimedia, Inc.\",\"logo\":{\"@type\":\"ImageObject\",\"url\":\"https:\\/\\/www.wikimedia.org\\/static\\/images\\/wmf-hor-googpub.png\"}},\"datePublished\":\"2004-02-24T13:56:25Z\",\"dateModified\":\"2024-11-03T19:25:21Z\",\"image\":\"https:\\/\\/upload.wikimedia.org\\/wikipedia\\/commons\\/6\\/6a\\/%C3%89mile_Loubet.jpg\",\"headline\":\"homme d'\\u00c9tat fran\\u00e7ais\"}</script>\n",
       "</body>\n",
       "</html>\n"
@@ -3015,7 +3032,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 106,
+   "execution_count": 18,
    "metadata": {
     "id": "h79ahwJvr7p-"
    },
@@ -3033,7 +3050,7 @@
       "  </title>\n",
       "  <script>\n",
       "   (function(){var className=\"client-js vector-feature-language-in-header-enabled vector-feature-language-in-main-page-header-disabled vector-feature-sticky-header-disabled vector-feature-page-tools-pinned-disabled vector-feature-toc-pinned-clientpref-1 vector-feature-main-menu-pinned-disabled vector-feature-limited-width-clientpref-1 vector-feature-limited-width-content-enabled vector-feature-custom-font-size-clientpref-1 vector-feature-appearance-pinned-clientpref-1 vector-feature-night-mode-enabled skin-theme-clientpref-day vector-toc-available\";var cookie=document.cookie.match(/(?:^|; )frwikimwclientpreferences=([^;]+)/);if(cookie){cookie[1].split('%2C').forEach(function(pref){className=className.replace(new RegExp('(^| )'+pref.replace(/-clientpref-\\w+$|[^\\w-]+/g,'')+'-clientpref-\\\\w+( |$)'),'$1'+pref+'$2');});}document.documentElement.className=className;}());RLCONF={\"wgBreakFrames\":false,\"wgSeparatorTransformTable\":[\",\\t.\",\" \\t,\"],\"wgDigitTransformTable\":[\"\",\"\"],\n",
-      "\"wgDefaultDateFormat\":\"dmy\",\"wgMonthNames\":[\"\",\"janvier\",\"février\",\"mars\",\"avril\",\"mai\",\"juin\",\"juillet\",\"août\",\"septembre\",\"octobre\",\"novembre\",\"décembre\"],\"wgRequestId\":\"1413c6ee-09fd-43cf-98b5-bb822a24195d\",\"wgCanonicalNamespace\":\"\",\"wgCanonicalSpecialPageName\":false,\"wgNamespaceNumber\":0,\"wgPageName\":\"Émile_Loubet\",\"wgTitle\":\"Émile Loubet\",\"wgCurRevisionId\":219996891,\"wgRevisionId\":219996891,\"wgArticleId\":53684,\"wgIsArticle\":true,\"wgIsRedirect\":false,\"wgAction\":\"view\",\"wgUserName\":null,\"wgUserGroups\":[\"*\"],\"wgCategories\":[\"Article utilisant une Infobox\",\"Article à référence nécessaire\",\"Catégorie Commons avec lien local identique sur Wikidata\",\"Page utilisant P11152\",\"Page utilisant P1808\",\"Page utilisant P1045\",\"Page pointant vers des bases externes\",\"Page pointant vers des bases relatives à la vie publique\",\"Page utilisant P1816\",\"Page pointant vers des bases relatives aux beaux-arts\",\"Page utilisant P1417\",\"Page utilisant P5019\",\"Page utilisant P8313\",\n",
+      "\"wgDefaultDateFormat\":\"dmy\",\"wgMonthNames\":[\"\",\"janvier\",\"février\",\"mars\",\"avril\",\"mai\",\"juin\",\"juillet\",\"août\",\"septembre\",\"octobre\",\"novembre\",\"décembre\"],\"wgRequestId\":\"e02916fc-bed3-47b0-b020-bc30eb87d255\",\"wgCanonicalNamespace\":\"\",\"wgCanonicalSpecialPageName\":false,\"wgNamespaceNumber\":0,\"wgPageName\":\"Émile_Loubet\",\"wgTitle\":\"Émile Loubet\",\"wgCurRevisionId\":219996891,\"wgRevisionId\":219996891,\"wgArticleId\":53684,\"wgIsArticle\":true,\"wgIsRedirect\":false,\"wgAction\":\"view\",\"wgUserName\":null,\"wgUserGroups\":[\"*\"],\"wgCategories\":[\"Article utilisant une Infobox\",\"Article à référence nécessaire\",\"Catégorie Commons avec lien local identique sur Wikidata\",\"Page utilisant P11152\",\"Page utilisant P1808\",\"Page utilisant P1045\",\"Page pointant vers des bases externes\",\"Page pointant vers des bases relatives à la vie publique\",\"Page utilisant P1816\",\"Page pointant vers des bases relatives aux beaux-arts\",\"Page utilisant P1417\",\"Page utilisant P5019\",\"Page utilisant P8313\",\n",
       "\"Page utilisant P7902\",\"Page utilisant P6404\",\"Page utilisant P6706\",\"Page utilisant P3222\",\"Page utilisant P4342\",\"Page utilisant P3365\",\"Page utilisant P3219\",\"Page utilisant P7666\",\"Page pointant vers des dictionnaires ou encyclopédies généralistes\",\"Article de Wikipédia avec notice d'autorité\",\"Portail:Politique française/Articles liés\",\"Portail:Politique/Articles liés\",\"Portail:France/Articles liés\",\"Portail:Europe/Articles liés\",\"Portail:Drôme/Articles liés\",\"Portail:Auvergne-Rhône-Alpes/Articles liés\",\"Wikipédia:Article biographique\",\"Portail:Biographie/Articles liés/Politique\",\"Portail:Biographie/Articles liés/Entreprises\",\"Émile Loubet\",\"Naissance en décembre 1838\",\"Naissance dans la Drôme provençale\",\"Étudiant de la faculté de droit de Paris\",\"Personnalité liée à la Drôme provençale\",\"Conseiller général de la Drôme\",\"Député de la Drôme (Troisième République)\",\"Député de la première législature de la Troisième République\",\n",
       "\"Député de la deuxième législature de la Troisième République\",\"Député de la troisième législature de la Troisième République\",\"Maire de Montélimar\",\"Sénateur de la Troisième République française\",\"Sénateur de la Drôme\",\"Ministre de la Troisième République\",\"Ministre français des Transports\",\"Président du Conseil de la Troisième République\",\"Président du Sénat (France)\",\"Président de la République française\",\"Personnalité de l'Alliance démocratique\",\"Dreyfusard\",\"Grand-croix de la Légion d'honneur\",\"Chevalier de l'ordre de Saint-André\",\"Chevalier de l'ordre espagnol de la Toison d'or (XXe siècle)\",\"Coprince d'Andorre du XIXe siècle\",\"Coprince d'Andorre du XXe siècle\",\"Décès en décembre 1929\",\"Décès à Montélimar\",\"Décès à 90 ans\",\"Personnalité inhumée dans la Drôme\"],\"wgPageViewLanguage\":\"fr\",\"wgPageContentLanguage\":\"fr\",\"wgPageContentModel\":\"wikitext\",\"wgRelevantPageName\":\"Émile_Loubet\",\"wgRelevantArticleId\":53684,\n",
       "\"wgIsProbablyEditable\":true,\"wgRelevantPageIsProbablyEditable\":true,\"wgRestrictionEdit\":[],\"wgRestrictionMove\":[],\"wgNoticeProject\":\"wikipedia\",\"wgCiteReferencePreviewsActive\":true,\"wgMediaViewerOnClick\":true,\"wgMediaViewerEnabledByDefault\":true,\"wgPopupsFlags\":0,\"wgVisualEditor\":{\"pageLanguageCode\":\"fr\",\"pageLanguageDir\":\"ltr\",\"pageVariantFallbacks\":\"fr\"},\"wgMFDisplayWikibaseDescriptions\":{\"search\":true,\"watchlist\":true,\"tagline\":true,\"nearby\":true},\"wgWMESchemaEditAttemptStepOversample\":false,\"wgWMEPageLength\":30000,\"wgRelatedArticlesCompat\":[],\"wgCentralAuthMobileDomain\":false,\"wgEditSubmitButtonLabelPublish\":true,\"wgULSPosition\":\"interlanguage\",\"wgULSisCompactLinksEnabled\":false,\"wgVector2022LanguageInHeader\":true,\"wgULSisLanguageSelectorEmpty\":false,\"wgWikibaseItemId\":\"Q169502\",\"wgCheckUserClientHintsHeadersJsApi\":[\"architecture\",\"bitness\",\"brands\",\"fullVersionList\",\"mobile\",\"model\",\"platform\",\"platformVersion\"],\"GEHomepageSuggestedEditsEnableTopics\":true,\n",
@@ -12724,7 +12741,7 @@
       "   </ul>\n",
       "  </div>\n",
       "  <script>\n",
-      "   (RLQ=window.RLQ||[]).push(function(){mw.config.set({\"wgHostname\":\"mw-web.eqiad.main-6b6c9bdc8b-88khx\",\"wgBackendResponseTime\":206,\"wgPageParseReport\":{\"limitreport\":{\"cputime\":\"1.303\",\"walltime\":\"1.653\",\"ppvisitednodes\":{\"value\":16389,\"limit\":1000000},\"postexpandincludesize\":{\"value\":403027,\"limit\":2097152},\"templateargumentsize\":{\"value\":116931,\"limit\":2097152},\"expansiondepth\":{\"value\":17,\"limit\":100},\"expensivefunctioncount\":{\"value\":7,\"limit\":500},\"unstrip-depth\":{\"value\":0,\"limit\":20},\"unstrip-size\":{\"value\":14014,\"limit\":5000000},\"entityaccesscount\":{\"value\":10,\"limit\":400},\"timingprofile\":[\"100.00% 1335.769      1 -total\",\" 37.52%  501.166      1 Modèle:Liens\",\" 22.57%  301.540      1 Modèle:Infobox_Personnalité_politique\",\" 11.97%  159.913     20 Modèle:Infobox_Personnalité_politique/Fonction\",\"  9.72%  129.795      1 Modèle:Palette\",\"  8.08%  107.961    585 Modèle:Infobox/Ligne_mixte_optionnelle\",\"  7.07%   94.378      2 Modèle:Références\",\"  6.19%   82.726      6 Modèle:Méta_palette_de_navigation\",\"  4.50%   60.160      1 Modèle:Portail\",\"  3.61%   48.171     32 Modèle:Infobox/Ligne_optionnelle\"]},\"scribunto\":{\"limitreport-timeusage\":{\"value\":\"0.581\",\"limit\":\"10.000\"},\"limitreport-memusage\":{\"value\":9671216,\"limit\":52428800}},\"cachereport\":{\"origin\":\"mw-web.eqiad.main-6b6c9bdc8b-kj2nb\",\"timestamp\":\"20241103192646\",\"ttl\":2592000,\"transientcontent\":false}}});});\n",
+      "   (RLQ=window.RLQ||[]).push(function(){mw.config.set({\"wgHostname\":\"mw-web.eqiad.main-56895c6b89-qrttm\",\"wgBackendResponseTime\":179,\"wgPageParseReport\":{\"limitreport\":{\"cputime\":\"1.303\",\"walltime\":\"1.653\",\"ppvisitednodes\":{\"value\":16389,\"limit\":1000000},\"postexpandincludesize\":{\"value\":403027,\"limit\":2097152},\"templateargumentsize\":{\"value\":116931,\"limit\":2097152},\"expansiondepth\":{\"value\":17,\"limit\":100},\"expensivefunctioncount\":{\"value\":7,\"limit\":500},\"unstrip-depth\":{\"value\":0,\"limit\":20},\"unstrip-size\":{\"value\":14014,\"limit\":5000000},\"entityaccesscount\":{\"value\":10,\"limit\":400},\"timingprofile\":[\"100.00% 1335.769      1 -total\",\" 37.52%  501.166      1 Modèle:Liens\",\" 22.57%  301.540      1 Modèle:Infobox_Personnalité_politique\",\" 11.97%  159.913     20 Modèle:Infobox_Personnalité_politique/Fonction\",\"  9.72%  129.795      1 Modèle:Palette\",\"  8.08%  107.961    585 Modèle:Infobox/Ligne_mixte_optionnelle\",\"  7.07%   94.378      2 Modèle:Références\",\"  6.19%   82.726      6 Modèle:Méta_palette_de_navigation\",\"  4.50%   60.160      1 Modèle:Portail\",\"  3.61%   48.171     32 Modèle:Infobox/Ligne_optionnelle\"]},\"scribunto\":{\"limitreport-timeusage\":{\"value\":\"0.581\",\"limit\":\"10.000\"},\"limitreport-memusage\":{\"value\":9671216,\"limit\":52428800}},\"cachereport\":{\"origin\":\"mw-web.eqiad.main-6b6c9bdc8b-kj2nb\",\"timestamp\":\"20241103192646\",\"ttl\":2592000,\"transientcontent\":false}}});});\n",
       "  </script>\n",
       "  <script type=\"application/ld+json\">\n",
       "   {\"@context\":\"https:\\/\\/schema.org\",\"@type\":\"Article\",\"name\":\"\\u00c9mile Loubet\",\"url\":\"https:\\/\\/fr.wikipedia.org\\/wiki\\/%C3%89mile_Loubet\",\"sameAs\":\"http:\\/\\/www.wikidata.org\\/entity\\/Q169502\",\"mainEntity\":\"http:\\/\\/www.wikidata.org\\/entity\\/Q169502\",\"author\":{\"@type\":\"Organization\",\"name\":\"Contributeurs aux projets Wikimedia\"},\"publisher\":{\"@type\":\"Organization\",\"name\":\"Fondation Wikimedia, Inc.\",\"logo\":{\"@type\":\"ImageObject\",\"url\":\"https:\\/\\/www.wikimedia.org\\/static\\/images\\/wmf-hor-googpub.png\"}},\"datePublished\":\"2004-02-24T13:56:25Z\",\"dateModified\":\"2024-11-03T19:25:21Z\",\"image\":\"https:\\/\\/upload.wikimedia.org\\/wikipedia\\/commons\\/6\\/6a\\/%C3%89mile_Loubet.jpg\",\"headline\":\"homme d'\\u00c9tat fran\\u00e7ais\"}\n",
@@ -12759,7 +12776,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 19,
    "metadata": {
     "id": "Vs8HeBx19oyC"
    },
@@ -12798,7 +12815,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 128,
+   "execution_count": 20,
    "metadata": {
     "id": "0DduDXaQALau"
    },
@@ -12847,7 +12864,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 129,
+   "execution_count": 21,
    "metadata": {
     "id": "wQORoweDHARO"
    },
@@ -12855,18 +12872,62 @@
    "source": [
     "# 10 lines\n",
     "def get_first_paragraph(wikipedia_url):\n",
-    "    print(wikipedia_url) # keep this for the rest of the notebook\n",
-    "#   [insert your code]\n",
-    "#   return first_paragraph"
+    "    leader_first_name = None\n",
+    "\n",
+    "    for country_code, leaders in leaders_per_country.items():\n",
+    "        for leader in leaders:\n",
+    "            if leader['wikipedia_url'] == wikipedia_url:\n",
+    "                leader_first_name = leader['first_name']\n",
+    "                break\n",
+    "        if leader_first_name:\n",
+    "                break\n",
+    "        \n",
+    "    if not leader_first_name:\n",
+    "         print(\"Leader not found for this URL.\")\n",
+    "         return None\n",
+    "\n",
+    "    print(wikipedia_url)\n",
+    "\n",
+    "    req_leader_wiki_url = requests.get(wikipedia_url)\n",
+    "    soup = BeautifulSoup(req_leader_wiki_url.content, 'html.parser')\n",
+    "\n",
+    "    paragraphs = [p.text for p in soup.find_all(\"p\")]\n",
+    "\n",
+    "    for first_paragraph in paragraphs:\n",
+    "        if first_paragraph.strip():\n",
+    "            first_word = first_paragraph.lstrip().split()[0].strip(string.punctuation).lower()\n",
+    "            if first_word == leader_first_name.lower():\n",
+    "                return first_paragraph\n",
+    "            \n",
+    "    return None"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 22,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "https://fr.wikipedia.org/wiki/Emmanuel_Macron\n",
+      "Emmanuel Macron ([ɛmanɥɛl makʁɔ̃][e] Écouter), né le 21 décembre 1977 à Amiens (Somme), est un haut fonctionnaire, banquier d'affaires et homme d'État français. Il est Président de la République française depuis le 14 mai 2017.\n",
+      "\n",
+      "https://en.wikipedia.org/wiki/George_Washington\n",
+      "George Washington (February 22, 1732 – December 14, 1799) was a Founding Father of the United States, military officer, and farmer who served as the first president of the United States from 1789 to 1797. Appointed by the Second Continental Congress as commander of the Continental Army in 1775, Washington led Patriot forces to victory in the American Revolutionary War and then served as president of the Constitutional Convention in 1787, which drafted the current Constitution of the United States. Washington has thus become commonly known as the \"Father of his Country\".\n",
+      "\n",
+      "https://ru.wikipedia.org/wiki/%D0%9F%D1%83%D1%82%D0%B8%D0%BD,_%D0%92%D0%BB%D0%B0%D0%B4%D0%B8%D0%BC%D0%B8%D1%80_%D0%92%D0%BB%D0%B0%D0%B4%D0%B8%D0%BC%D0%B8%D1%80%D0%BE%D0%B2%D0%B8%D1%87\n",
+      "None\n"
+     ]
+    }
+   ],
    "source": [
-    "# Test: 3 lines\n"
+    "# Test: 3 lines\n",
+    "print(get_first_paragraph('https://fr.wikipedia.org/wiki/Emmanuel_Macron'))\n",
+    "print(get_first_paragraph('https://en.wikipedia.org/wiki/George_Washington'))\n",
+    "# Problem because dictionary had English name while the url is in Cyrillic\n",
+    "print(get_first_paragraph('https://ru.wikipedia.org/wiki/%D0%9F%D1%83%D1%82%D0%B8%D0%BD,_%D0%92%D0%BB%D0%B0%D0%B4%D0%B8%D0%BC%D0%B8%D1%80_%D0%92%D0%BB%D0%B0%D0%B4%D0%B8%D0%BC%D0%B8%D1%80%D0%BE%D0%B2%D0%B8%D1%87'))"
    ]
   },
   {
@@ -12890,7 +12951,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 23,
    "metadata": {
     "id": "7DHEAb6oBUxd"
    },
@@ -12911,7 +12972,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 24,
    "metadata": {
     "id": "voT-jzd7FMOc"
    },
@@ -12931,7 +12992,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 25,
    "metadata": {
     "id": "NOmkLM9JFRCp"
    },
@@ -12955,7 +13016,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 26,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -12964,7 +13025,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 27,
    "metadata": {
     "id": "RICG4T3DPZ1b"
    },
@@ -12989,7 +13050,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 28,
    "metadata": {
     "id": "rgPd2dxgJiW1"
    },
@@ -13010,7 +13071,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 29,
    "metadata": {
     "id": "mPXT-cxgKQof"
    },
@@ -13034,7 +13095,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 30,
    "metadata": {
     "id": "XTEVLIJ-V7z1"
    },
@@ -13056,7 +13117,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 31,
    "metadata": {
     "id": "Kt6JtKDpOAIe"
    },
@@ -13098,7 +13159,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 32,
    "metadata": {
     "id": "pTNGKKrOjNDk"
    },
@@ -13119,7 +13180,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 33,
    "metadata": {
     "id": "4VwNjBYyjPzs"
    },
@@ -13139,7 +13200,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 34,
    "metadata": {
     "id": "EfknpnTljqUd"
    },
@@ -13150,7 +13211,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 35,
    "metadata": {
     "id": "lWQ6bbn31cix"
    },


### PR DESCRIPTION
This function retrieves the first paragraph that starts with the leader's first name by searching the dictionary for a matching URL. Works in most cases but has limitations with non-Latin alphabet pages, as the names in the dictionary are in English while the URLs may lead to pages in other scripts.